### PR TITLE
Bugfix: Unusual device locations should not crash the program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+MYMETA.json
+MYMETA.yml
+Makefile
+blib/
+pm_to_blib

--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Contributors:
     miz <miz999@gmail.com>
     Tim Engler <engler@gmail.com>
     Thomas Liske <thomas@fiasko-nw.net>
+    Ted Lyngmo <ted@lyncon.se>

--- a/examples/dms2vodcast.pl
+++ b/examples/dms2vodcast.pl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/bin/env perl
 
 use Net::UPnP::ControlPoint;
 use Net::UPnP::AV::MediaServer;

--- a/examples/upnpavchk.pl
+++ b/examples/upnpavchk.pl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/bin/env perl
 
 use Net::UPnP::ControlPoint;
 use Net::UPnP::AV::MediaServer;

--- a/examples/upnpavdump.pl
+++ b/examples/upnpavdump.pl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/bin/env perl
 
 use Net::UPnP::ControlPoint;
 use Net::UPnP::AV::MediaServer;

--- a/examples/upnpavsimple.pl
+++ b/examples/upnpavsimple.pl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/bin/env perl
 
 use Net::UPnP::ControlPoint;
 

--- a/examples/upnpchk.pl
+++ b/examples/upnpchk.pl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/bin/env perl
 
 use Net::UPnP::ControlPoint;
 

--- a/examples/upnpdump.pl
+++ b/examples/upnpdump.pl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/bin/env perl
 
 use Net::UPnP::ControlPoint;
 

--- a/examples/upnpgwdump.pl
+++ b/examples/upnpgwdump.pl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/bin/env perl
 
 use Net::UPnP::ControlPoint;
 use Net::UPnP::GW::Gateway;

--- a/examples/upnpgwtool.pl
+++ b/examples/upnpgwtool.pl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/bin/env perl
 
 use Net::UPnP::ControlPoint;
 use Net::UPnP::GW::Gateway;

--- a/lib/Net/UPnP/ControlPoint.pm
+++ b/lib/Net/UPnP/ControlPoint.pm
@@ -86,12 +86,14 @@ SSDP_SEARCH_MSG
 			next;
 		}		
 		$dev_location = $1;
-		unless ($dev_location =~ m/http:\/\/([0-9a-z.]+)[:]*([0-9]*)\/(.*)/i) {
+		print "dev_location=$dev_location\n" if ($Net::UPnP::DEBUG);
+                unless ($dev_location =~ m{http://([0-9a-z.-]+)(?::(\d+))?/(.*)}i) {
 			next;
 		}
 		$dev_addr = $1;
-		$dev_port = $2;
+		$dev_port = $2 || 80;
 		$dev_path = '/' . $3;
+		print "dev_addr=$dev_addr dev_port=$dev_port dev_path=$dev_path\n" if ($Net::UPnP::DEBUG);
 		
 		$http_req = Net::UPnP::HTTP->new();
 		$post_res = $http_req->post($dev_addr, $dev_port, "GET", $dev_path, "", "");

--- a/lib/Net/UPnP/HTTP.pm
+++ b/lib/Net/UPnP/HTTP.pm
@@ -82,7 +82,10 @@ REQUEST_HEADER
 
 	$post_sockaddr = sockaddr_in($post_port, inet_aton($post_addr));
 	socket(HTTP_SOCK, PF_INET, SOCK_STREAM, getprotobyname('tcp'));
-	connect(HTTP_SOCK, $post_sockaddr);
+	unless( connect(HTTP_SOCK, $post_sockaddr) ) {
+            print "connect($post_addr:$post_port) failed: $!" if ($Net::UPnP::DEBUG);
+            return "";
+        }
 	select(HTTP_SOCK); $|=1; select(STDOUT);
 
 	if ($Net::UPnP::DEBUG) {


### PR DESCRIPTION
* Bugfix: The ControlPoint search method will not crash when encountering a
  device location using the http schema default port (80). If the port is
  omitted, port 80 will be used.
* Bugfix: Add hyphen (-) as a valid character in the host part of the device
  location.
* Bugfix: POST:ing to a device that refuses connections will now not crash
  the program. An empty string ("") will be returned instead.
* Make the dev_location regex fail if a colon (:) is not followed by a port
  number.
* Add a few debug prints around the device location and connection.
* Replace the shebang in the examples with "#!/usr/bin/env perl" to make them
  work on systems with perl installed in other places.
* Add .gitignore for generated files.