### PR TITLE
Fallback for deprecated QueryStateVariable(PortMappingNumberOfEntries)

### DIFF
--- a/examples/upnpgwdump.pl
+++ b/examples/upnpgwdump.pl
@@ -27,7 +27,7 @@ foreach $dev (@dev_list) {
 	print "\tExternalIPAddress = " . $gwdev->getexternalipaddress() . "\n";
 	print "\tPortMappingNumberOfEntries = " . $gwdev->getportmappingnumberofentries() . "\n";
 	print "\tTotalBytesRecived = " . $gwdev->gettotalbytesrecieved() . "\n";
-	@port_mapping = $gwdev->getportmappingentry();
+	@port_mapping = $gwdev->getportmappingentries();
 	$port_num = 0;
 	foreach $port_entry (@port_mapping) {
 		if ($port_entry) {

--- a/examples/upnpgwtool.pl
+++ b/examples/upnpgwtool.pl
@@ -117,7 +117,7 @@ print $dev->getfriendlyname() . "\n";
 if ($command eq "list") {
 	print " ExternalIPAddress = " . $gwdev->getexternalipaddress() . "\n";
 	print " PortMappingNumberOfEntries = " . $gwdev->getportmappingnumberofentries() . "\n";
-	@port_mapping = $gwdev->getportmappingentry();
+	@port_mapping = $gwdev->getportmappingentries();
 	$port_num = 0;
 	foreach $port_entry (@port_mapping) {
 		if ($port_entry) {

--- a/lib/Net/UPnP/ControlPoint.pm
+++ b/lib/Net/UPnP/ControlPoint.pm
@@ -88,6 +88,7 @@ SSDP_SEARCH_MSG
 		$dev_location = $1;
 		print "dev_location=$dev_location\n" if ($Net::UPnP::DEBUG);
                 unless ($dev_location =~ m{http://([0-9a-z.-]+)(?::(\d+))?/(.*)}i) {
+                        print "bad dev_location: $dev_location\n" if ($Net::UPnP::DEBUG);
 			next;
 		}
 		$dev_addr = $1;

--- a/lib/Net/UPnP/HTTP.pm
+++ b/lib/Net/UPnP/HTTP.pm
@@ -70,12 +70,15 @@ REQUEST_HEADER
 
 	#print "header = " . %{$add_header} . "\n";
 	#%add_header = %{$add_header_ref};
+        my $has_connection_header;
 	if (ref $add_header) {
+                $has_connection_header = 1 if( defined ${$add_header}{'Connection'} );
 		while ( ($add_header_name, $add_header_value) =  each %{$add_header}) {
 			$req_header .= "$add_header_name: $add_header_value\n";
 		}
 	}
 
+	$req_header .= "Connection: close\n" unless( $has_connection_header );
 	$req_header .= "\n";
 	$req_header =~ s/\r//g;
 	$req_header =~ s/\n/\r\n/g;
@@ -179,7 +182,7 @@ sub postsoap {
 }
 
 #------------------------------
-# postsoap
+# xmldecode
 #------------------------------
 
 sub xmldecode {

--- a/lib/Net/UPnP/QueryResponse.pm
+++ b/lib/Net/UPnP/QueryResponse.pm
@@ -99,7 +99,7 @@ sub getvalue() {
 	$value = "";
 	
 	$res_content = $http_res->getcontent();
-	if ($res_content =~ m/<return>(.*?)<\/return>/si) {
+	if ($res_content =~ m{<return>(.*?)</return>}si) {
 		$value = $1;
 	}
 

--- a/lib/Net/UPnP/Service.pm
+++ b/lib/Net/UPnP/Service.pm
@@ -143,7 +143,7 @@ sub getposturl() {
 	#print "$url_base\n";
 	#print "$ctrl_url\n";
 		
-	unless ($ctrl_url =~ m/http:\/\/(.*)/i) {
+	unless ($ctrl_url =~ m{http://(.*)}i) {
 		if (0 < length($url_base)) {
 			# Thanks for Thus0 (2005/01/12)
 			if (rindex($url_base, '/') == (length($url_base)-1) && index($ctrl_url, '/') == 0) {
@@ -153,11 +153,12 @@ sub getposturl() {
 			}
 		}
 		else {
-			if ($location_url =~ m/http:\/\/([0-9a-z.]+)[:]*([0-9]*)\/(.*)/i) {
+			if ($location_url =~ m{http://([0-9a-z.-]+)(?::(\d+))?/(.*)}i) {
+                                my $port = $2 || 80;
 				if (defined($3) && 0 < length($3)) {
-					$ctrl_url = "http:\/\/" . $1 . ":" . $2 . $ctrl_url;
+					$ctrl_url = 'http://' . $1 . ":" . $port . $ctrl_url;
 				} else {
-					$ctrl_url = "http:\/\/" . $1 . ":" . $2 . "\/" . $ctrl_url;
+					$ctrl_url = 'http://' . $1 . ":" . $port . '/' . $ctrl_url;
 				}
 			} else {
 				$ctrl_url = $location_url .  $ctrl_url;
@@ -198,23 +199,23 @@ sub postaction() {
 	$ctrl_url = $this->getcontrolurl();
 	$ctrl_url = $this->getposturl($ctrl_url);
 	
-	unless ($ctrl_url =~ m/http:\/\/([0-9a-z.]+)[:]*([0-9]*)\/(.*)/i) {
+	unless ($ctrl_url =~ m{http://([0-9a-z.-]+)(?::(\d+))?/(.*)}i) {
 		#print "Invalid URL : $ctrl_url\n";
 		$post_res = Net::UPnP::HTTPResponse->new();
 		$action_res->sethttpresponse($post_res);
 		return $action_res;
 	}
 	$post_addr = $1;
-	$post_port = $2;
+	$post_port = $2 || 80;
 	if (index($3, '/') == 0) {
 		$post_path = $3;
 	}
 	else {
-		$post_path = "\/" . $3;
+		$post_path = '/' . $3;
 	}
 
 	$service_type = $this->getservicetype();
-	$soap_action = "\"" . $service_type . "#" . $action_name . "\"";
+	$soap_action = '"' . $service_type . '#' . $action_name . '"';
 
 
 $soap_content = <<"SOAP_CONTENT";
@@ -285,23 +286,23 @@ sub postquery() {
 	$ctrl_url = $this->getcontrolurl();
 	$ctrl_url = $this->getposturl($ctrl_url);
 	
-	unless ($ctrl_url =~ m/http:\/\/([0-9a-z.]+)[:]*([0-9]*)\/(.*)/i) {
-		#print "Invalid URL : $ctrl_url\n";
+        print "ctrl_url=$ctrl_url\n" if ($Net::UPnP::DEBUG);
+	unless ($ctrl_url =~ m{http://([0-9a-z.-]+)(?::(\d+))?/(.*)}i) {
 		$post_res = Net::UPnP::HTTPResponse->new();
 		$query_res->sethttpresponse($post_res);
 		return $query_res;
 	}
 	$post_addr = $1;
-	$post_port = $2;
+	$post_port = $2 || 80;
 	if (index($3, '/') == 0) {
 		$post_path = $3;
 	}
 	else {
-		$post_path = "\/" . $3;
+		$post_path = '/' . $3;
 	}
-	
 	$service_type = $this->getservicetype();
-	$soap_action = "\"urn:schemas-upnp-org:control-1-0#QueryStateVariable\"";
+	$soap_action = '"urn:schemas-upnp-org:control-1-0#QueryStateVariable"';
+
 
 $soap_content = <<"SOAP_CONTENT";
 <?xml version=\"1.0\" encoding=\"utf-8\"?>


### PR DESCRIPTION
* GW::Gateway::getportmappingnumberofentries will start by trying
  QueryStateVariable(PortMappingNumberOfEntries). If it gets an empty string
  in return it'll call getportmappingentries and return the number if entries in
  the returned list. The method is here for backwards compatibility. It's
  better to call getportmappingentries and see how many entries you got.

* GW::Gateway::getportmappingentry is renamed getportmappingentries but the old
  name remains for backwards compatibility.

* GW::Gateway::getportmappingentries will not do a
  QueryStateVariable(PortMappingNumberOfEntries) before populating the list of
  port mappings. It now starts directly at index 0 and increases the index until
  it fails.

* m{http://([0-9a-z.-]+)(?::(\d+))?/(.*)} is used everywhere when regex:ing a
  location.

* The Connection field will now always be explicitly set in the HTTP methods.
  If supplied via the extra args, that's the value that will be used, otherwise
  "Connection: close" will be used. Some devices don't handle HTTP/1.0 and
  HTTP/1.1 differently and since the default for HTTP/1.0 is that the connection
  should be closed, and for HTTP/1.1 it's for the connection to be persistent,
  it's better to be explicit.